### PR TITLE
Ansible generate web report 2025 08 13 t224918.024483+0000

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
                                     <button class="device-button" data-device="ansible_1">
                                             ansible_1
                                     </button>
-                                            </div>
+                                                                </div>
 
     <!-- PDF Download Button -->
     <div class="pdf-button-container">
@@ -267,7 +267,7 @@
                     <li><b>OS Type:</b> cisco.ios.ios</li>
                     <li><b>Serial:</b> 9MQ1VO4W4H7</li>
                     <li><b>Version:</b> 17.13.01a</li>
-                    <li><b>Mem Free (MB):</b> 1826101.33203125</li>
+                    <li><b>Mem Free (MB):</b> 1826949.4375</li>
                     <li><b>Mem Total (MB):</b> 2017116.1796875</li>
                                                          </ul>
 
@@ -357,6 +357,22 @@
                     </div>
                                                                  
                                                                                  
+            </div> <!-- End Main Content -->
+        </div> <!-- End Container -->
+    </div> <!-- End Device Content -->
+        <div class="device-content" id="device-ansible_2">
+        <div class="container">
+            <!-- Sidebar -->
+            <div class="sidebar">
+                <h2>Device Information</h2>
+                                                                                <p class="no-data">Basic device facts could not be gathered for this device.</p>
+                            </div>
+
+            <!-- Main Content -->
+            <div class="main-content">
+                <!-- Tabs - Only render if facts_all exist -->
+                                 <p class="no-data">Could not load main facts_all ('all_gathered_resources') for this device (ansible_2). Please check Ansible logs for fact gathering issues.</p>
+                                 
             </div> <!-- End Main Content -->
         </div> <!-- End Container -->
     </div> <!-- End Device Content -->


### PR DESCRIPTION
## Summary by Sourcery

Add error placeholders for ansible_2 device in the generated web report and apply minor HTML formatting and data updates

New Features:
- Add a new section for 'ansible_2' device with no-data placeholders when fact gathering fails

Enhancements:
- Fix indentation of the device-button container closing tag
- Update the displayed 'Mem Free (MB)' value for the ansible_1 device